### PR TITLE
Add github-action for continuous delivery.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,27 @@
+name: Delivery
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Run dnt & minify
+        run: |
+          npm install -g esbuild
+          deno task dnt
+          deno task minify > ./npm/.min.js
+      - working-directory: ./npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
@chris-wood I've added a github-action for continuous delivery.

Could you do the following two things before merging this PR or releasing the next version?
- Get NPM_TOKEN from npmjs and set it to this repository via settings > secrets > actions.
- Add the webhook to this repo for publishing this ohttp module on [deno.land](https://deno.land/). It is very easy if you press the "+ Publish a module" button from the following page and follow the guide.
    - https://deno.land/x 