### PR TITLE
Add APIs for encoding and decoding key configs for wire transmission

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -146,6 +146,42 @@
     "https://deno.land/x/hpke@v0.15.0/src/utils/misc.ts": "62f5f9b90d964c45c776dfac9298df04de8b16840df65de8b78b8e0deb51c9f5",
     "https://deno.land/x/hpke@v0.15.0/src/webCrypto.ts": "a922b106660d0f573742f49d2a450ba0ba19189aeeeecdcd756556b0c1ccb69d",
     "https://deno.land/x/hpke@v0.15.0/src/xCryptoKey.ts": "abc71ddfad0e6239b9ee4daf40123bbec1a56204af7b7e6ac7ca7556a7223f7a",
+    "https://deno.land/x/hpke@v0.18.2/mod.ts": "e9f7d6b58f11fa6962ab69c523f592a6a7802167557c9d2b551d75c57b6847fc",
+    "https://deno.land/x/hpke@v0.18.2/src/aeadKeys/aesGcmKey.ts": "410f778e1c0074054dd90d8a8095d0deda17819b92110345c4bb5fa119c21243",
+    "https://deno.land/x/hpke@v0.18.2/src/aeadKeys/chacha20Poly1305Key.ts": "dd3388f9a4cf6a1b4070157170f35f25a8db8f7f353f0525c02676280e802880",
+    "https://deno.land/x/hpke@v0.18.2/src/cipherSuite.ts": "cf59ec665fb136fd20b519b001e2b215031418cf68d83d42b875e419241c8845",
+    "https://deno.land/x/hpke@v0.18.2/src/consts.ts": "98cf8b1a4cd370964208cb292bafa196c5722fbb900d486112a0c206a77f2252",
+    "https://deno.land/x/hpke@v0.18.2/src/encryptionContext.ts": "3656e21119473b908b597cd0953477edb7cac48327a56305fd832fadb6b9ac10",
+    "https://deno.land/x/hpke@v0.18.2/src/errors.ts": "05822bd1d483cd1fdf515b26398f8c270b8561fa94dc818f6bc3c7031415ccf0",
+    "https://deno.land/x/hpke@v0.18.2/src/exporterContext.ts": "5856fac0ee24ea056e1cb575bafe3e1704a9228711e3d0d042ef0f38d72c28f3",
+    "https://deno.land/x/hpke@v0.18.2/src/identifiers.ts": "f39f229a5e4ed3d1367edb455c8359e5716b2968afa76c8a7f39200a83fc6ced",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/aeadKey.ts": "07fab95e38966f64042a92bfa7b3079f1e63f1357c194e4accdfd514c60039e4",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/aeadParams.ts": "8f58fc1b918e7a12236a63c364066d88a5dde80ec44eaad8f979f8b649476e90",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/cipherSuiteParams.ts": "459c82bb894cc1323b61d5ccc45b23695fa8db2c7444d514054e5a41b68747bf",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/encapsulator.ts": "6a81362683e1eb9f7406bb974b6b7bd5554bc6c93eed3ab3e955a9dda9beca48",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/encryptionContextInterface.ts": "329c1ee876540713351a5eb77888c48a7296388293a0d320b757e252a08fc328",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/exporter.ts": "6667607ba48f02ec447f143d1e0050adbe11cd7857c8dce3670dd5a8a9298e91",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/kdfInterface.ts": "64f9e88a961f16ddaa941edeb01b393ea0e5aa844189e0d45c90b92422299bf8",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/kemInterface.ts": "dfb415e359402444bbf6612826a447f18fcd7c9759f2db6d184f8a395a7b8e1d",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/kemPrimitives.ts": "5f2d7926174480dc76181f7040f9647d5c908059268f08d60742d101e9439766",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/keyInfo.ts": "8cc05de2a7e0c446913393c3a340eda323bc6338bf2152d9aa648c2d47712546",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/keyScheduleParams.ts": "e0a698815eb123c914de499de71bde80a79b4488e6ce681fbb394037ba2a9645",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/preSharedKey.ts": "98543f61362b5f77675f4f5f13af4efdf58183c3c309f539d6c6c9cb62124090",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/recipientContextParams.ts": "02194c133714506d12524c7828ff80464e089534ac8c1a08eb1e7913c6f24ce2",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/responses.ts": "35d2bf77ab4d32cfe90bf96d3a61bf92a10a3979e90be74f64965da019c46531",
+    "https://deno.land/x/hpke@v0.18.2/src/interfaces/senderContextParams.ts": "f57ffc17222e79d87c4f7730fb826c0ba6860c5ace1d06aeddde29c5618f362e",
+    "https://deno.land/x/hpke@v0.18.2/src/kdfs/hkdf.ts": "c5cb59c7c23f989c91645340af22ed053f79e2081bd9ebdf9cc8ae153094c7f8",
+    "https://deno.land/x/hpke@v0.18.2/src/kems/dhkem.ts": "64779b48889babef56f0b91864f6fd7d84af296bedea2c0be16018020ec31bf9",
+    "https://deno.land/x/hpke@v0.18.2/src/kems/dhkemPrimitives/ec.ts": "9294192969df9bd2f0892b00a6c700ff476a7a87452f499f2107fd0844fb8778",
+    "https://deno.land/x/hpke@v0.18.2/src/kems/dhkemPrimitives/secp256k1.ts": "d4b9b08cbc7c9ecfcdcc019d8b39048997039602f630340560b6cbaff093b5a2",
+    "https://deno.land/x/hpke@v0.18.2/src/kems/dhkemPrimitives/x25519.ts": "c233be4853cfefe7944d7b130a646879f11ca5858d474b8d41ab0145d7faec0b",
+    "https://deno.land/x/hpke@v0.18.2/src/kems/dhkemPrimitives/x448.ts": "20ac5356a6c74924625bd9543fc9c5f936116268b6854efcc9822151154f52b1",
+    "https://deno.land/x/hpke@v0.18.2/src/recipientContext.ts": "228ba51bc52df0387617a3f471d43b3ec4f7b6d142c0f7f395d282a09f6ceae9",
+    "https://deno.land/x/hpke@v0.18.2/src/senderContext.ts": "e4a4381b9dfbae61309c5ed4fe92db973df57b704c6d200afe8bfc4a3e845e47",
+    "https://deno.land/x/hpke@v0.18.2/src/utils/bignum.ts": "2e8749a21cde3ec81e4d353ec001732d60c22d56a717f83bec4c9ddf8227f75c",
+    "https://deno.land/x/hpke@v0.18.2/src/utils/misc.ts": "c8da27a83f6f43f5b02aa323ed7ccfa475d5dd8a4d04e9df553827be51d59e0a",
+    "https://deno.land/x/hpke@v0.18.2/src/webCrypto.ts": "a922b106660d0f573742f49d2a450ba0ba19189aeeeecdcd756556b0c1ccb69d",
+    "https://deno.land/x/hpke@v0.18.2/src/xCryptoKey.ts": "abc71ddfad0e6239b9ee4daf40123bbec1a56204af7b7e6ac7ca7556a7223f7a",
     "https://deno.land/x/ts_morph@15.1.0/bootstrap/mod.ts": "b53aad517f106c4079971fcd4a81ab79fadc40b50061a3ab2b741a09119d51e9",
     "https://deno.land/x/ts_morph@15.1.0/bootstrap/ts_morph_bootstrap.d.ts": "2be47f54ceb6ef524ed0e2e9f80776d93276a1edadfa2191680927dadd3ccd76",
     "https://deno.land/x/ts_morph@15.1.0/bootstrap/ts_morph_bootstrap.js": "e0d65e4c209038948221437bad543df2092c93f76ab76c60eb203e9f108a793a",
@@ -155,5 +191,76 @@
     "https://deno.land/x/ts_morph@15.1.0/common/ts_morph_common.js": "e43476019b9c74ca9116eb82b97a14e6bc2d1bba55b0575d933d98069c0c0c37",
     "https://deno.land/x/ts_morph@15.1.0/common/typescript.d.ts": "3fa86a2c33804b6a4221dda3714a6a2f8a2f26983ea6c63d2bf6f2839fbb778a",
     "https://deno.land/x/ts_morph@15.1.0/common/typescript.js": "4d7a5d2090a2ba739c02207bd8c49a60c9475dea7725a9cabfaf0f26cbf85f53"
+  },
+  "npm": {
+    "specifiers": {
+      "@noble/curves@0.5.1": "@noble/curves@0.5.1",
+      "@noble/hashes@1.1.5": "@noble/hashes@1.1.5",
+      "@noble/secp256k1@1.7.1": "@noble/secp256k1@1.7.1",
+      "@stablelib/chacha20poly1305@1.0.1": "@stablelib/chacha20poly1305@1.0.1"
+    },
+    "packages": {
+      "@noble/curves@0.5.1": {
+        "integrity": "sha512-Z0X7t/tptOR9/i+TjXNNIX5GFaArDqkbE7w4FaFUVLhx4B152g862fiHGyQMIhPxjEtBo6shbd23fJRy86Y6oA==",
+        "dependencies": {
+          "@noble/hashes": "@noble/hashes@1.1.5"
+        }
+      },
+      "@noble/hashes@1.1.5": {
+        "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+        "dependencies": {}
+      },
+      "@noble/secp256k1@1.7.1": {
+        "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+        "dependencies": {}
+      },
+      "@stablelib/aead@1.0.1": {
+        "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==",
+        "dependencies": {}
+      },
+      "@stablelib/binary@1.0.1": {
+        "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+        "dependencies": {
+          "@stablelib/int": "@stablelib/int@1.0.1"
+        }
+      },
+      "@stablelib/chacha20poly1305@1.0.1": {
+        "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+        "dependencies": {
+          "@stablelib/aead": "@stablelib/aead@1.0.1",
+          "@stablelib/binary": "@stablelib/binary@1.0.1",
+          "@stablelib/chacha": "@stablelib/chacha@1.0.1",
+          "@stablelib/constant-time": "@stablelib/constant-time@1.0.1",
+          "@stablelib/poly1305": "@stablelib/poly1305@1.0.1",
+          "@stablelib/wipe": "@stablelib/wipe@1.0.1"
+        }
+      },
+      "@stablelib/chacha@1.0.1": {
+        "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+        "dependencies": {
+          "@stablelib/binary": "@stablelib/binary@1.0.1",
+          "@stablelib/wipe": "@stablelib/wipe@1.0.1"
+        }
+      },
+      "@stablelib/constant-time@1.0.1": {
+        "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
+        "dependencies": {}
+      },
+      "@stablelib/int@1.0.1": {
+        "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+        "dependencies": {}
+      },
+      "@stablelib/poly1305@1.0.1": {
+        "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+        "dependencies": {
+          "@stablelib/constant-time": "@stablelib/constant-time@1.0.1",
+          "@stablelib/wipe": "@stablelib/wipe@1.0.1"
+        }
+      },
+      "@stablelib/wipe@1.0.1": {
+        "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
+        "dependencies": {}
+      }
+    }
   }
 }

--- a/import-map.json
+++ b/import-map.json
@@ -2,7 +2,7 @@
   "imports": {
     "testing/": "https://deno.land/std@0.163.0/testing/",
     "dnt": "https://deno.land/x/dnt@0.31.0/mod.ts",
-    "hpke": "https://deno.land/x/hpke@v0.15.0/mod.ts",
+    "hpke": "https://deno.land/x/hpke@v0.18.2/mod.ts",
     "bhttp": "https://deno.land/x/bhttp@v0.2.1/mod.ts"
   }
 }

--- a/test/ohttp.test.ts
+++ b/test/ohttp.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertStrictEquals } from "testing/asserts.ts";
 import { describe, it } from "testing/bdd.ts";
 
-import { Client, KeyConfig, Server } from "../src/ohttp.ts";
+import { Client, ClientConstructor, KeyConfig, Server } from "../src/ohttp.ts";
 
 describe("test OHTTP end-to-end", () => {
   it("Happy Path", async () => {
@@ -28,17 +28,19 @@ describe("test OHTTP end-to-end", () => {
   it("Happy Path with encoding and decoding", async () => {
     const keyId = 0x01;
     const keyConfig = new KeyConfig(keyId);
-    const publicKeyConfig = await keyConfig.publicConfig();
+    const server = new Server(keyConfig);
+
+    const encodedKeyConfig = await server.encodeKeyConfig();
 
     const encodedRequest = new TextEncoder().encode("Happy");
     const encodedResponse = new TextEncoder().encode("Path");
 
-    const client = new Client(publicKeyConfig);
+    const constructor = new ClientConstructor();
+    const client = await constructor.clientForConfig(encodedKeyConfig);
     const requestContext = await client.encapsulate(encodedRequest);
     const clientRequest = requestContext.request;
     const encodedClientRequest = clientRequest.encode();
 
-    const server = new Server(keyConfig);
     const responseContext = await server.decodeAndDecapsulate(
       encodedClientRequest,
     );


### PR DESCRIPTION
Closes #7.

This lets applications transfer the key config over the wire from gateway to client. 